### PR TITLE
Fix Frida set userdefaults command

### DIFF
--- a/Module-4/README.md
+++ b/Module-4/README.md
@@ -467,8 +467,8 @@ If you've played around with the `CoinZa` application, you've probably noticed t
 - Up until this point all you've done is following the same steps that you did with `Cydia` but with `Frida`'s interactive console. But you have one step left, enabling the pro version:
     ```javascript
     function setProVersion() {
-    	var userDefaultsClass = ObjC.classes.NSUserDefaults;
-    	userDefaultsClass.setObject_forKey_(true,'isProVersion');
+    	var userDefaultsClass = ObjC.classes.NSUserDefaults.standardUserDefaults();
+    	userDefaultsClass.setObject_forKey_('YES', 'isProVersion');
     }
     ```
 - Now if you increase the balance of any wallet you'll get an extra 20% for free!


### PR DESCRIPTION
Using Frida 15.1.8 I noticed that `ObjC.classes.NSUserDefaults` hasn't `setObject_forKey_` method and `userDefaultsClass.setObject_forKey_(true, 'isProVersion');` is returning 

```
Error: expected a pointer
    at m (<input>:1)
```

Instead of this, I'm using 
```
var userDefaultsClass = ObjC.classes.NSUserDefaults.standardUserDefaults();
userDefaultsClass.setObject_forKey_('YES', 'isProVersion');
```

and it is working as expected!